### PR TITLE
Const bitfield

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 #![cfg_attr(test, no_main)]
 #![feature(custom_test_frameworks)]
 #![feature(abi_x86_interrupt)]
+#![feature(const_trait_impl)]
 #![test_runner(crate::test::runner)]
 #![reexport_test_harness_main = "test_main"]
 

--- a/src/utils/bitfield.rs
+++ b/src/utils/bitfield.rs
@@ -19,7 +19,7 @@ pub trait ConstBitGetter: Sized {
     /// # Arguments
     ///
     /// * `start` - The range's starting offset.
-    /// * `end` - The range's ending offset.
+    /// * `end` - The range's excluded ending offset.
     ///
     /// # Panics
     ///
@@ -46,7 +46,7 @@ pub trait ConstBitSetter: Sized {
     /// # Arguments
     ///
     /// * `start` - The range's starting offset.
-    /// * `end` - The range's ending offset.
+    /// * `end` - The range's excluded ending offset.
     ///
     /// # Panics
     ///

--- a/src/utils/bitfield.rs
+++ b/src/utils/bitfield.rs
@@ -14,6 +14,16 @@ pub trait ConstBitGetter: Sized {
     /// This method will panics if the given index is out of range.
     fn get_bit(self, idx: usize) -> bool;
 
+    /// Return a value representing the state of a range of bits.
+    ///
+    /// # Arguments
+    ///
+    /// * `start` - The range's starting offset.
+    /// * `end` - The range's ending offset.
+    ///
+    /// # Panics
+    ///
+    /// This method will panics if the given range is invalid.
     fn get_range(self, start: usize, end: usize) -> Self;
 }
 
@@ -31,6 +41,16 @@ pub trait ConstBitSetter: Sized {
     /// This method will panics if the given index is out of range.
     fn set_bit(self, idx: usize, value: bool) -> Self;
 
+    /// Set a range of bits to the given value.
+    ///
+    /// # Arguments
+    ///
+    /// * `start` - The range's starting offset.
+    /// * `end` - The range's ending offset.
+    ///
+    /// # Panics
+    ///
+    /// This method will panics if the given range is invalid.
     fn set_range(self, start: usize, end: usize, value: Self) -> Self;
 }
 

--- a/src/utils/bitfield.rs
+++ b/src/utils/bitfield.rs
@@ -180,6 +180,29 @@ fn to_regular_range<T: RangeBounds<usize>>(range: &T, maximun: usize) -> Range<u
 }
 
 #[cfg(test)]
+mod range_conversion_tests {
+    use super::*;
+
+    #[test_case]
+    fn simple_range_start() {
+        let range = 1..2;
+        assert_eq!(to_regular_range(&range, 5).start, 1)
+    }
+
+    #[test_case]
+    fn simple_range_stop() {
+        let range = 1..2;
+        assert_eq!(to_regular_range(&range, 5).end, 2)
+    }
+
+    #[test_case]
+    fn range_stop() {
+        let range = 1..=2;
+        assert_eq!(to_regular_range(&range, 5).end, 3)
+    }
+}
+
+#[cfg(test)]
 mod get_tests {
     use super::*;
 


### PR DESCRIPTION
The initial intent of this pull request was to provide a new macro api to bitfield's builder patterns. This is not possible, however we may keep the const functions designed for it. This way we could provide a compile time const expansion to some bitfield setup.