### PR TITLE
Fix descriptor tables

### DIFF
--- a/src/arch/ia32/descriptor/segment.rs
+++ b/src/arch/ia32/descriptor/segment.rs
@@ -106,7 +106,7 @@ impl From<SegmentType> for u8 {
 /// A segment descriptor structure that can be used directly by the
 /// processor to describe a memory segment.
 #[must_use]
-#[derive(Default, Copy, Clone)]
+#[derive(Copy, Clone)]
 #[repr(C, packed)]
 pub struct SegmentDescriptor {
     /// Bits 0 to 15 of the segment's limit.
@@ -124,6 +124,25 @@ pub struct SegmentDescriptor {
 }
 
 impl SegmentDescriptor {
+
+    /// Create a new null [`SegmentDescriptor`].
+    pub const fn const_default() -> Self {
+        SegmentDescriptor {
+            /// Bits 0 to 15 of the segment's limit.
+            limit_15_0: 0,
+            /// Bits 0 to 15 of the segment's base address.
+            base_15_0: 0,
+            /// Bits 16 to 23 of the segment's base address.
+            base_23_16: 0,
+            /// The segment's permissions (Type, S, DPL, P).
+            permissions: Permissions::const_default(),
+            /// The segment's configuration (limit bits 16 to 19, AVL, L, D/B, G).
+            configuration: Configuration::const_default(),
+            /// Bits 24 to 31 of the segment's base address.
+            base_31_24: 0,
+        }
+    }
+
     /// Create a new [`SegmentDescriptor`] from an address and a limit
     /// with all other flags set to their default value.
     ///
@@ -279,6 +298,10 @@ impl fmt::Display for SegmentDescriptor {
     }
 }
 
+impl Default for SegmentDescriptor {
+    fn default() -> Self { Self::const_default() }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -287,6 +310,16 @@ mod tests {
     fn structure_size() {
         use core::mem::size_of;
         assert_eq!(size_of::<SegmentDescriptor>(), 8);
+    }
+
+    #[test_case]
+    fn default_is_null() {
+        let seg = SegmentDescriptor::default();
+
+        assert_eq!(
+            unsafe { core::mem::transmute::<SegmentDescriptor, u64>(seg) },
+            0
+        )
     }
 
     #[test_case]

--- a/src/arch/ia32/descriptor/segment/configuration.rs
+++ b/src/arch/ia32/descriptor/segment/configuration.rs
@@ -35,6 +35,12 @@ mod offset {
 }
 
 impl Configuration {
+
+    /// Create a new null [`Configuration`].
+    pub const fn const_default() -> Self {
+        Configuration(0)
+    }
+
     /// Get the bits (19:16) of the limit value stored in the configuration
     /// field.
     pub fn get_limit(&self) -> u8 {

--- a/src/arch/ia32/descriptor/segment/permissions.rs
+++ b/src/arch/ia32/descriptor/segment/permissions.rs
@@ -45,6 +45,12 @@ mod offset {
 }
 
 impl Permissions {
+
+    /// Create a new null [`Permissions`].
+    pub const fn const_default() -> Self {
+        Permissions(0)
+    }
+
     /// Change a [`Permissions`]'s segment type value.
     ///
     /// # Arguments

--- a/src/arch/ia32/interrupts/idt.rs
+++ b/src/arch/ia32/interrupts/idt.rs
@@ -9,14 +9,14 @@ const IDT_LEN: usize = 256;
 pub struct InterruptDescriptorTable(pub [Gate; IDT_LEN]);
 
 impl InterruptDescriptorTable {
-    pub fn load(self) {
+    pub fn load(&'static self) {
         trace!("Loading interrupt descriptor table...");
 
         let idtr = InterruptDescriptorTableRegister::new(
             (IDT_LEN * mem::size_of::<Gate>())
                 .try_into()
                 .expect("Idt length does not fit in a u16, cannot set IDTR"),
-            addr_of!(self),
+            self,
         );
 
         unsafe {

--- a/src/arch/ia32/mm/gdt.rs
+++ b/src/arch/ia32/mm/gdt.rs
@@ -9,14 +9,14 @@ const GDT_LEN: usize = 5;
 pub struct GlobalDescriptorTable(pub [SegmentDescriptor; GDT_LEN]);
 
 impl GlobalDescriptorTable {
-    pub fn load(self) {
+    pub fn load(&'static self) {
         trace!("Loading global descriptor table...");
 
         let gdtr = GlobalDescriptorTableRegister::new(
             (GDT_LEN * mem::size_of::<SegmentDescriptor>())
                 .try_into()
                 .expect("Gdt length does not fit in a u16, cannot set GDTR"),
-            addr_of!(self),
+            self,
         );
 
         unsafe {

--- a/src/arch/ia32/selector.rs
+++ b/src/arch/ia32/selector.rs
@@ -1,7 +1,21 @@
 use crate::arch::ia32::PrivilegeLevel;
 
-#[derive(Default, Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub struct SegmentSelector(u16);
+
+impl SegmentSelector {
+
+    /// Create a new null [`SegmentSelector`].
+    pub const fn const_default() -> Self {
+        SegmentSelector(0)
+    }
+}
+
+impl Default for SegmentSelector {
+    fn default() -> Self {
+        Self::const_default()
+    }
+}
 
 #[repr(u8)]
 pub enum TableIndicator {

--- a/src/arch/ia32e/descriptor/gate.rs
+++ b/src/arch/ia32e/descriptor/gate.rs
@@ -72,7 +72,7 @@ impl Gate {
     /// # Note
     ///
     /// The present bit will be enabled when using this constructor.
-    pub fn new(offset: u64, segment_selector: SegmentSelector) -> Self {
+    fn new(offset: u64, segment_selector: SegmentSelector) -> Self {
         Self {
             offset_15_0: offset.get_bits(0..16).try_into().unwrap(),
             offset_31_16: offset.get_bits(16..32).try_into().unwrap(),
@@ -81,6 +81,36 @@ impl Gate {
             segment_selector,
             ..Default::default()
         }
+    }
+
+    /// Creates a new interrupt [`Gate`] from a given offset and segment
+    /// selector.
+    ///
+    /// # Arguments
+    ///
+    /// * `base` - The segments base adress.
+    /// * `limit` - The limit value for the segment descriptor.
+    ///
+    /// # Note
+    ///
+    /// The present bit will be enabled when using this constructor.
+    pub fn interrupt(offset: u64, segment_selector: SegmentSelector) -> Self {
+        Self::new(offset, segment_selector).kind(Kind::Interrupt)
+    }
+
+    /// Creates a new trap [`Gate`] from a given offset and segment
+    /// selector.
+    ///
+    /// # Arguments
+    ///
+    /// * `base` - The segments base adress.
+    /// * `limit` - The limit value for the segment descriptor.
+    ///
+    /// # Note
+    ///
+    /// The present bit will be enabled when using this constructor.
+    pub fn trap(offset: u64, segment_selector: SegmentSelector) -> Self {
+        Self::new(offset, segment_selector).kind(Kind::Trap)
     }
 
     /// Set or clear the presence bit of the [`Gate`].

--- a/src/arch/ia32e/descriptor/gate.rs
+++ b/src/arch/ia32e/descriptor/gate.rs
@@ -24,7 +24,7 @@ impl From<Kind> for u16 {
 /// A gate descriptor structure that can be used to describe either a trap gate
 /// or an interrupt gate. This structure can be used directly by the processor.
 #[must_use]
-#[derive(Default, Copy, Clone)]
+#[derive(Copy, Clone)]
 #[repr(C, packed)]
 pub struct Gate {
     /// Bits 0 to 15 of the interrupt routine address.
@@ -42,6 +42,25 @@ pub struct Gate {
 }
 
 impl Gate {
+
+    /// Create a new null [`Gate`].
+    pub const fn const_default() -> Self {
+        Gate {
+             /// Bits 0 to 15 of the interrupt routine address.
+            offset_15_0: 0,
+            /// The segment selector to use on interrupt/trap.
+            segment_selector: SegmentSelector::const_default(),
+            /// The configuration of the gate descriptor.
+            configuration: Configuration::const_default(),
+            /// Bits 16 to 31 of the interrupt routine address.
+            offset_31_16: 0,
+            /// Bits 32 to 63 of the interrupt routine address.
+            offset_63_32: 0,
+            /// Reserved bits.
+            _reserved: 0,
+        }
+    }
+
     /// Creates a new interrupt/trap [`Gate`] from a given offset and segment
     /// selector.
     ///
@@ -115,6 +134,12 @@ impl Gate {
             configuration: self.configuration.interrupt_stack_table(ist),
             ..self
         }
+    }
+}
+
+impl Default for Gate {
+    fn default() -> Self {
+        Self::const_default()
     }
 }
 

--- a/src/arch/ia32e/descriptor/gate/configuration.rs
+++ b/src/arch/ia32e/descriptor/gate/configuration.rs
@@ -12,7 +12,7 @@ use core::fmt;
 /// - Gate type (TYPE)
 /// - Descriptor privilege level (DPL)
 /// - Present bit (P)
-#[derive(Default, Copy, Clone)]
+#[derive(Copy, Clone)]
 pub struct Configuration(u16);
 
 /// The set of all field offsets for the [`Configuration`] structure.
@@ -44,6 +44,12 @@ mod offset {
 }
 
 impl Configuration {
+
+    /// Create a new null [`Configuration`].
+    pub const fn const_default() -> Self {
+        Configuration(0)
+    }
+
     /// Change a [`Configuration`]'s privilege level by another one.
     ///
     /// # Arguments
@@ -104,6 +110,12 @@ impl fmt::Display for Configuration {
             self.0.get_bits(kind::LOWER..=kind::UPPER),
             self.0.get_bits(ist::LOWER..=ist::UPPER)
         )
+    }
+}
+
+impl Default for Configuration {
+    fn default() -> Self {
+        Self::const_default()
     }
 }
 

--- a/src/arch/ia32e/interrupts/idt.rs
+++ b/src/arch/ia32e/interrupts/idt.rs
@@ -2,6 +2,7 @@ use crate::arch::ia32e::{
     descriptor::gate::Gate,
     selector::{SegmentSelector, TableIndicator},
     PrivilegeLevel,
+    descriptor::gate::Kind
 };
 use core::arch::asm;
 use core::ptr::addr_of;
@@ -15,23 +16,29 @@ pub struct InterruptDescriptorTable {
     pub entries: [Gate; IDT_LEN],
 }
 
-impl Default for InterruptDescriptorTable {
-    fn default() -> Self {
+impl InterruptDescriptorTable {
+    pub const fn const_default() -> Self {
         Self {
-            entries: [Gate::default(); IDT_LEN],
+            entries: [Gate::const_default(); IDT_LEN],
         }
     }
 }
 
+impl Default for InterruptDescriptorTable {
+    fn default() -> Self {
+        Self::const_default()
+    }
+}
+
 impl InterruptDescriptorTable {
-    pub fn load(self) {
+    pub fn load(&'static self) {
         trace!("Loading interrupt descriptor table...");
 
         let idtr = InterruptDescriptorTableRegister::new(
             (IDT_LEN * mem::size_of::<Gate>())
                 .try_into()
                 .expect("Idt length does not fit in a u16, cannot set IDTR"),
-            addr_of!(self),
+            self,
         );
 
         unsafe {
@@ -66,65 +73,79 @@ impl InterruptDescriptorTableRegister {
     }
 }
 
-fn setup_predefined(idt: &mut InterruptDescriptorTable) {
+static mut IDT: InterruptDescriptorTable = InterruptDescriptorTable::const_default();
+
+unsafe fn setup_predefined() {
     let kernel_segment =
         SegmentSelector::new(GDT_KERNEL_CODE, TableIndicator::GDT, PrivilegeLevel::Kernel);
 
     // Divide error
-    idt.entries[0] = Gate::new(div_by_zero as *const () as u64, kernel_segment).present(true);
+    IDT.entries[0] = Gate::new(div_by_zero as *const () as u64, kernel_segment).present(true).kind(Kind::Interrupt);
     // Debug exception
-    idt.entries[1] = Gate::new(0, kernel_segment).present(false);
+    IDT.entries[1] = Gate::new(0, kernel_segment).present(false);
     // NMI interrupt
-    idt.entries[2] = Gate::new(0, kernel_segment).present(false);
+    IDT.entries[2] = Gate::new(0, kernel_segment).present(false);
     // Breakpoint
-    idt.entries[3] = Gate::new(0, kernel_segment).present(false);
+    IDT.entries[3] = Gate::new(breakpoint as *const () as u64, kernel_segment).present(true).kind(Kind::Interrupt);
     // Overflow
-    idt.entries[4] = Gate::new(0, kernel_segment).present(false);
+    IDT.entries[4] = Gate::new(0, kernel_segment).present(false);
     // Bound range exceeded
-    idt.entries[5] = Gate::new(0, kernel_segment).present(false);
+    IDT.entries[5] = Gate::new(0, kernel_segment).present(false);
     // Invalid OP code
-    idt.entries[6] = Gate::new(0, kernel_segment).present(false);
+    IDT.entries[6] = Gate::new(0, kernel_segment).present(false);
     // Device not available
-    idt.entries[7] = Gate::new(0, kernel_segment).present(false);
+    IDT.entries[7] = Gate::new(0, kernel_segment).present(false);
     // Double fault
-    idt.entries[8] = Gate::new(double_fault as *const () as u64, kernel_segment).present(true);
+    IDT.entries[8] = Gate::new(double_fault as *const () as u64, kernel_segment).present(true).kind(Kind::Interrupt);
     // Coprocessor segment overrun
-    idt.entries[9] = Gate::new(0, kernel_segment).present(false);
+    IDT.entries[9] = Gate::new(0, kernel_segment).present(false);
     // Invalid TSS
-    idt.entries[10] = Gate::new(0, kernel_segment).present(false);
+    IDT.entries[10] = Gate::new(0, kernel_segment).present(false);
     // Segment not present
-    idt.entries[11] = Gate::new(0, kernel_segment).present(false);
+    IDT.entries[11] = Gate::new(0, kernel_segment).present(false);
     // Stack segment fault
-    idt.entries[12] = Gate::new(0, kernel_segment).present(false);
+    IDT.entries[12] = Gate::new(0, kernel_segment).present(false);
     // General protection
-    idt.entries[13] = Gate::new(0, kernel_segment).present(false);
+    IDT.entries[13] = Gate::new(0, kernel_segment).present(false);
     // Page fault
-    idt.entries[14] = Gate::new(0, kernel_segment).present(false);
+    IDT.entries[14] = Gate::new(0, kernel_segment).present(false);
     // x87 fpu floating point error
-    idt.entries[16] = Gate::new(0, kernel_segment).present(false);
+    IDT.entries[16] = Gate::new(0, kernel_segment).present(false);
     // Alignment check
-    idt.entries[17] = Gate::new(0, kernel_segment).present(false);
+    IDT.entries[17] = Gate::new(0, kernel_segment).present(false);
     // Machine check
-    idt.entries[18] = Gate::new(0, kernel_segment).present(false);
+    IDT.entries[18] = Gate::new(0, kernel_segment).present(false);
     // SIMD floating point Exception
-    idt.entries[19] = Gate::new(0, kernel_segment).present(false);
+    IDT.entries[19] = Gate::new(0, kernel_segment).present(false);
     // Virtualization exception
-    idt.entries[20] = Gate::new(0, kernel_segment).present(false);
+    IDT.entries[20] = Gate::new(0, kernel_segment).present(false);
     // Control protection exception
-    idt.entries[21] = Gate::new(0, kernel_segment).present(false);
+    IDT.entries[21] = Gate::new(0, kernel_segment).present(false);
 }
 
 pub fn setup_idt() {
-    trace!("Setting up idt...");
-    let mut idt = InterruptDescriptorTable::default();
-    setup_predefined(&mut idt);
+    unsafe {
+        trace!("Setting up idt...");
+        setup_predefined();
+        trace!("Loading idt...");
+        IDT.load();
+    }
 
-    todo!("Add idt loading");
-    //idt.load();
+    /*unsafe {
+        asm!("int3", options(nomem, nostack));
+    }*/
+
+    loop {
+
+    }
 }
 
 extern "x86-interrupt" fn div_by_zero() {
     panic!("Division by zero");
+}
+
+extern "x86-interrupt" fn breakpoint() {
+    panic!("Breakpoint");
 }
 
 extern "x86-interrupt" fn double_fault() {

--- a/src/arch/ia32e/interrupts/idt.rs
+++ b/src/arch/ia32e/interrupts/idt.rs
@@ -80,47 +80,47 @@ unsafe fn setup_predefined() {
         SegmentSelector::new(GDT_KERNEL_CODE, TableIndicator::GDT, PrivilegeLevel::Kernel);
 
     // Divide error
-    IDT.entries[0] = Gate::new(div_by_zero as *const () as u64, kernel_segment).present(true).kind(Kind::Interrupt);
+    IDT.entries[0] = Gate::interrupt(div_by_zero as *const () as u64, kernel_segment);
     // Debug exception
-    IDT.entries[1] = Gate::new(0, kernel_segment).present(false);
+    IDT.entries[1] = Gate::interrupt(0, kernel_segment).present(false);
     // NMI interrupt
-    IDT.entries[2] = Gate::new(0, kernel_segment).present(false);
+    IDT.entries[2] = Gate::interrupt(0, kernel_segment).present(false);
     // Breakpoint
-    IDT.entries[3] = Gate::new(breakpoint as *const () as u64, kernel_segment).present(true).kind(Kind::Interrupt);
+    IDT.entries[3] = Gate::interrupt(breakpoint as *const () as u64, kernel_segment).present(true);
     // Overflow
-    IDT.entries[4] = Gate::new(0, kernel_segment).present(false);
+    IDT.entries[4] = Gate::interrupt(0, kernel_segment).present(false);
     // Bound range exceeded
-    IDT.entries[5] = Gate::new(0, kernel_segment).present(false);
+    IDT.entries[5] = Gate::interrupt(0, kernel_segment).present(false);
     // Invalid OP code
-    IDT.entries[6] = Gate::new(0, kernel_segment).present(false);
+    IDT.entries[6] = Gate::interrupt(0, kernel_segment).present(false);
     // Device not available
-    IDT.entries[7] = Gate::new(0, kernel_segment).present(false);
+    IDT.entries[7] = Gate::interrupt(0, kernel_segment).present(false);
     // Double fault
-    IDT.entries[8] = Gate::new(double_fault as *const () as u64, kernel_segment).present(true).kind(Kind::Interrupt);
+    IDT.entries[8] = Gate::interrupt(double_fault as *const () as u64, kernel_segment).present(true);
     // Coprocessor segment overrun
-    IDT.entries[9] = Gate::new(0, kernel_segment).present(false);
+    IDT.entries[9] = Gate::interrupt(0, kernel_segment).present(false);
     // Invalid TSS
-    IDT.entries[10] = Gate::new(0, kernel_segment).present(false);
+    IDT.entries[10] = Gate::interrupt(0, kernel_segment).present(false);
     // Segment not present
-    IDT.entries[11] = Gate::new(0, kernel_segment).present(false);
+    IDT.entries[11] = Gate::interrupt(0, kernel_segment).present(false);
     // Stack segment fault
-    IDT.entries[12] = Gate::new(0, kernel_segment).present(false);
+    IDT.entries[12] = Gate::interrupt(0, kernel_segment).present(false);
     // General protection
-    IDT.entries[13] = Gate::new(0, kernel_segment).present(false);
+    IDT.entries[13] = Gate::interrupt(0, kernel_segment).present(false);
     // Page fault
-    IDT.entries[14] = Gate::new(0, kernel_segment).present(false);
+    IDT.entries[14] = Gate::interrupt(0, kernel_segment).present(false);
     // x87 fpu floating point error
-    IDT.entries[16] = Gate::new(0, kernel_segment).present(false);
+    IDT.entries[16] = Gate::interrupt(0, kernel_segment).present(false);
     // Alignment check
-    IDT.entries[17] = Gate::new(0, kernel_segment).present(false);
+    IDT.entries[17] = Gate::interrupt(0, kernel_segment).present(false);
     // Machine check
-    IDT.entries[18] = Gate::new(0, kernel_segment).present(false);
+    IDT.entries[18] = Gate::interrupt(0, kernel_segment).present(false);
     // SIMD floating point Exception
-    IDT.entries[19] = Gate::new(0, kernel_segment).present(false);
+    IDT.entries[19] = Gate::interrupt(0, kernel_segment).present(false);
     // Virtualization exception
-    IDT.entries[20] = Gate::new(0, kernel_segment).present(false);
+    IDT.entries[20] = Gate::interrupt(0, kernel_segment).present(false);
     // Control protection exception
-    IDT.entries[21] = Gate::new(0, kernel_segment).present(false);
+    IDT.entries[21] = Gate::interrupt(0, kernel_segment).present(false);
 }
 
 pub fn setup_idt() {

--- a/src/arch/ia32e/mm/gdt.rs
+++ b/src/arch/ia32e/mm/gdt.rs
@@ -5,56 +5,66 @@ use crate::arch::ia32::descriptor::segment::{
 use crate::arch::ia32::mm::gdt::GlobalDescriptorTable;
 use log::{debug, trace};
 
+static mut GDT: GlobalDescriptorTable = GlobalDescriptorTable([
+    SegmentDescriptor::const_default(),
+    SegmentDescriptor::const_default(),
+    SegmentDescriptor::const_default(),
+    SegmentDescriptor::const_default(),
+    SegmentDescriptor::const_default()
+]);
+
 pub fn setup_gdt() {
     trace!("Setting up 64bits gdt...");
-    let gdt = GlobalDescriptorTable([
-        // Null segment
-        SegmentDescriptor::default(),
-        // Kernel code
-        SegmentDescriptor::new(0, 0xFFFF)
-            .segment_type(SegmentType::Code {
-                accessed: false,
-                read: true,
-                conforming: false,
-            })
-            .descriptor_type(DescriptorType::CodeOrData)
-            .ia32e_mode(true)
-            .privilege_level(PrivilegeLevel::Kernel)
-            .granularity(Granularity::FourKByte),
-        // Kernel data
-        SegmentDescriptor::new(0, 0xFFFF)
-            .segment_type(SegmentType::Data {
-                accessed: false,
-                write: true,
-                expand_down: false,
-            })
-            .descriptor_type(DescriptorType::CodeOrData)
-            .privilege_level(PrivilegeLevel::Kernel)
-            .default_operation_size(DefaultOperationSize::Segment32Bits)
-            .granularity(Granularity::FourKByte),
-        // User code
-        SegmentDescriptor::new(0, 0xFFFF)
-            .segment_type(SegmentType::Code {
-                accessed: false,
-                read: true,
-                conforming: false,
-            })
-            .descriptor_type(DescriptorType::CodeOrData)
-            .ia32e_mode(true)
-            .privilege_level(PrivilegeLevel::Userland)
-            .granularity(Granularity::FourKByte),
-        // User data
-        SegmentDescriptor::new(0, 0xFFFF)
-            .segment_type(SegmentType::Data {
-                accessed: false,
-                write: true,
-                expand_down: false,
-            })
-            .descriptor_type(DescriptorType::CodeOrData)
-            .privilege_level(PrivilegeLevel::Userland)
-            .default_operation_size(DefaultOperationSize::Segment32Bits)
-            .granularity(Granularity::FourKByte),
-    ]);
-    debug!("GDT:\n{}", gdt);
-    gdt.load();
+    unsafe {
+        GDT = GlobalDescriptorTable([
+            // Null segment
+            SegmentDescriptor::default(),
+            // Kernel code
+            SegmentDescriptor::new(0, 0xFFFF)
+                .segment_type(SegmentType::Code {
+                    accessed: false,
+                    read: true,
+                    conforming: false,
+                })
+                .descriptor_type(DescriptorType::CodeOrData)
+                .ia32e_mode(true)
+                .privilege_level(PrivilegeLevel::Kernel)
+                .granularity(Granularity::FourKByte),
+            // Kernel data
+            SegmentDescriptor::new(0, 0xFFFF)
+                .segment_type(SegmentType::Data {
+                    accessed: false,
+                    write: true,
+                    expand_down: false,
+                })
+                .descriptor_type(DescriptorType::CodeOrData)
+                .privilege_level(PrivilegeLevel::Kernel)
+                .default_operation_size(DefaultOperationSize::Segment32Bits)
+                .granularity(Granularity::FourKByte),
+            // User code
+            SegmentDescriptor::new(0, 0xFFFF)
+                .segment_type(SegmentType::Code {
+                    accessed: false,
+                    read: true,
+                    conforming: false,
+                })
+                .descriptor_type(DescriptorType::CodeOrData)
+                .ia32e_mode(true)
+                .privilege_level(PrivilegeLevel::Userland)
+                .granularity(Granularity::FourKByte),
+            // User data
+            SegmentDescriptor::new(0, 0xFFFF)
+                .segment_type(SegmentType::Data {
+                    accessed: false,
+                    write: true,
+                    expand_down: false,
+                })
+                .descriptor_type(DescriptorType::CodeOrData)
+                .privilege_level(PrivilegeLevel::Userland)
+                .default_operation_size(DefaultOperationSize::Segment32Bits)
+                .granularity(Granularity::FourKByte),
+        ]);
+        debug!("GDT:\n{}", GDT);
+        GDT.load();
+    }
 }


### PR DESCRIPTION
This PR fixes the following issues:
- GDT was not static
- IDT was not static
- In the `Configuration` struct for *ia32e*, no `Kind` is given by default (should there be one ?). Hence, the gate for `div_by_zero` and `double_fault` were incorrect.

The IDT should not be working. You can uncomment the breakpoint instruction to test it.

Warning: this PR adds more unsafe